### PR TITLE
add demo dockercompose and mappings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  wiremock:
+    image: wiremock/wiremock:latest
+    container_name: wiremock
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./wiremock:/home/wiremock
+    command: --verbose --root-dir /home/wiremock

--- a/wiremock/mappings/balance.json
+++ b/wiremock/mappings/balance.json
@@ -1,0 +1,16 @@
+{
+    "request": {
+      "method": "GET",
+      "url": "/balance"
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": {
+        "balance": 1500.00
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+  

--- a/wiremock/mappings/payments.json
+++ b/wiremock/mappings/payments.json
@@ -1,0 +1,17 @@
+{
+    "request": {
+      "method": "POST",
+      "url": "/payments"
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": {
+        "transaction_id": "12345",
+        "status": "success"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+  

--- a/wiremock/mappings/withdraw.json
+++ b/wiremock/mappings/withdraw.json
@@ -1,0 +1,16 @@
+{
+    "request": {
+      "method": "POST",
+      "url": "/withdraw"
+    },
+    "response": {
+      "status": 400,
+      "jsonBody": {
+        "error": "Insufficient funds"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+  


### PR DESCRIPTION
## Closes #2 

### created a docker-compose.yml that will build WireMock in a container.

- Using the official wiremock/wiremock:latest image.
- The container will be available at http://localhost:8080.
- Mock files (response settings) will be stored in the local wiremock directory.
- The --verbose option enables logging of requests.
- The --root-dir /home/wiremock option allows us to store mock files in the mounted wiremock folder.

### created simple demonstration endpoints to simulate the banking API.

`wiremock/mappings/payments.json` file (payment)
When a client sends a POST request to /payments, WireMock returns a response:
```
{
  “transaction_id": “12345”,
  “status": “success”
}
```

`wiremock/mappings/withdraw.json` file (withdrawal)
We simulate the case when there are not enough funds on the account (400 Bad Request).

`wiremock/mappings/balance.json` file (balance check)
When we call GET /balance, we get the balance of 1500.00.